### PR TITLE
[3211] Add version to bundle name

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,8 @@
                 "@typescript-eslint/no-unsafe-assignment": "off",
                 "@typescript-eslint/no-unsafe-call": "off",
                 "@typescript-eslint/no-unsafe-return": "off",
-                "@typescript-eslint/no-unsafe-member-access": "off"
+                "@typescript-eslint/no-unsafe-member-access": "off",
+                "@typescript-eslint/restrict-template-expressions": "off"
             }
         }
     ]

--- a/articles/scp-3211/gulpfile.js
+++ b/articles/scp-3211/gulpfile.js
@@ -4,6 +4,10 @@ const ts = require("gulp-typescript")
 const cleanCss = require("gulp-clean-css")
 const webpack = require("webpack-stream")
 const TerserPlugin = require("terser-webpack-plugin")
+const { BannerPlugin } = require("webpack")
+const { compress } = require("compress-tag")
+
+const { version } = require("./package.json")
 
 gulp.task('clean', async done => {
   // Scrub any previous builds from dist
@@ -38,6 +42,14 @@ gulp.task('webpack', () => {
    * Bundle all the requirements for the JS that will run in the iframe into a
    * single file.
    */
+  const bannerText = compress`
+    3211.js version ${version}, generated ${new Date()}
+    \nThis file was generated for SCP-3211 and its translations in the
+    international SCP community.
+    \nSCP-3211-EN: https://scp-wiki.wikidot.com/scp-3211
+    \nSource: https://github.com/rossjrw/scp/tree/main/articles/scp-3211
+  `
+
   return gulp
     .src("./src/iframe.ts")
     .pipe(webpack({
@@ -54,7 +66,10 @@ gulp.task('webpack', () => {
         minimize: process.env.NODE_ENV === "production",
         minimizer: [ new TerserPlugin({ extractComments: false }) ],
         usedExports: true
-      }
+      },
+      plugins: [
+        new BannerPlugin(bannerText)
+      ]
     }).on("error", error => console.log("Webpack:", error)))
     .pipe(gulp.dest("./dist/"))
 })

--- a/articles/scp-3211/src/build.ts
+++ b/articles/scp-3211/src/build.ts
@@ -10,6 +10,7 @@ import util from "util"
 import { Anomaly, referenceAnomaly } from "./anomaly"
 import { anomalyNames, langs } from "./config"
 import { rot13 } from "./rot13"
+import { version } from "../package.json"
 
 export async function makeFtml (
   lang: keyof typeof langs,
@@ -48,7 +49,7 @@ export async function copyFiles (lang: keyof typeof langs): Promise<void> {
     }
   })
   fs.copyFileSync(`./src/assets/warning.svg`, `./dist/${lang}/warning.svg`)
-  fs.copyFileSync(`./dist/3211.js`, `./dist/${lang}/3211.js`)
+  fs.copyFileSync("./dist/3211.js", `./dist/${lang}/3211@${version}.js`)
 }
 
 async function makeIframe (lang: keyof typeof langs): Promise<string> {

--- a/articles/scp-3211/src/build.ts
+++ b/articles/scp-3211/src/build.ts
@@ -65,6 +65,7 @@ async function makeIframe (lang: keyof typeof langs): Promise<string> {
       deltas: JSON.stringify(deltas),
       css: fs.readFileSync("./build/iframe.css", "utf8"),
       fileUrl: langs[lang].fileUrl,
+      version,
       buttons: fs.readFileSync(`./src/${lang}/buttons.html`, "utf8"),
       warning: ejs.render(
         fs.readFileSync(`./src/${lang}/warning.ejs.html`, "utf8"),

--- a/articles/scp-3211/src/iframe.ejs.html
+++ b/articles/scp-3211/src/iframe.ejs.html
@@ -15,7 +15,7 @@
     window.lang = <%- lang %>
   </script>
 
-  <script src="<%- fileUrl %>3211.js"></script>
+  <script src="<%- fileUrl %>3211@<%- version %>.js"></script>
 </head>
 <body>
   <section id="buttons" class="hidden">

--- a/articles/scp-3211/tsconfig.json
+++ b/articles/scp-3211/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "lib": [ "es2020", "dom" ]
   },
   "include": [ "src/**/*.ts" ]


### PR DESCRIPTION
It's quickly going to get confusing seeing "Uploaded 3211.js" to the page and not having a clue what changed. Having a version in the filename will help - at least it won't be impossible to see what changed.

- [x] Add version to filename