### PR TITLE
[3211] Add Rot13 for JP

### DIFF
--- a/articles/scp-3211/src/rot13.ts
+++ b/articles/scp-3211/src/rot13.ts
@@ -11,5 +11,13 @@ export function rot13 (string: string): string {
         ? charCode
         : charCode - 26
     )
-  })
+  }).replace(/[ぁ-ゖ]/g, (char) => {
+    let charCode = char.charCodeAt(0)
+    return String.fromCharCode(charCode <= 12425 ? charCode + 13 : charCode - 73);
+  }).replace(/[ァ-ヶ]/g, (char) => {
+    let charCode = char.charCodeAt(0)
+    return String.fromCharCode(charCode <= 12521 ? charCode + 13 : charCode - 73);
+  }).replace(/[一-龠]/g, (char) => {
+    let charCode = char.charCodeAt(0)
+    return String.fromCharCode(charCode <= 40184 ? charCode + 13 : charCode - 20217);
 }

--- a/articles/scp-3211/src/rot13.ts
+++ b/articles/scp-3211/src/rot13.ts
@@ -20,4 +20,5 @@ export function rot13 (string: string): string {
   }).replace(/[一-龠]/g, (char) => {
     let charCode = char.charCodeAt(0)
     return String.fromCharCode(charCode <= 40184 ? charCode + 13 : charCode - 20217);
+  })
 }


### PR DESCRIPTION
For the time being, only the Japanese part is available for Rot13.
I'm new to ts, so maybe I didn't need the ";".
Please remove it after Merge.