### PR TITLE
[3211] Do not include config in bundle

### DIFF
--- a/articles/scp-3211/src/build.ts
+++ b/articles/scp-3211/src/build.ts
@@ -63,7 +63,7 @@ async function makeIframe (lang: keyof typeof langs): Promise<string> {
   const html = ejs.render(
     fs.readFileSync("./src/iframe.ejs.html", "utf8"),
     {
-      lang: JSON.stringify(lang),
+      lang: JSON.stringify(langs[lang]),
       reference: JSON.stringify(reference.split("\n")),
       deltas: JSON.stringify(deltas),
       css: fs.readFileSync("./build/iframe.css", "utf8"),

--- a/articles/scp-3211/src/config.ts
+++ b/articles/scp-3211/src/config.ts
@@ -14,7 +14,7 @@ export const anomalyNames = <const>[
   "cannon"
 ]
 
-type Lang = {
+export type Lang = {
   rot13: boolean
   fileUrl: string
 }

--- a/articles/scp-3211/src/iframe.ts
+++ b/articles/scp-3211/src/iframe.ts
@@ -1,13 +1,13 @@
 import { applyPatch } from "diff"
 import Cookies from "js-cookie"
 
-import type { anomalyNames, langs } from "./config"
+import type { anomalyNames, Lang } from "./config"
 import { rot13 } from "./rot13"
 
 // Defined in iframe.ejs.html
 declare const reference: string[]
 declare const anomalies: { [anomaly in typeof anomalyNames[number]]: string }
-declare const lang: keyof typeof langs
+declare const lang: Lang
 
 const sections = <const>["warning", "loading", "anomaly"]
 type section = typeof sections[number]
@@ -191,7 +191,7 @@ function nextSection (toSection: section) {
     // Construct the anomaly
     const anomalyElement = document.createElement('div')
     anomalyElement.innerHTML = (
-      langs[lang].rot13 ? rot13 : (patch: string) => patch
+      lang.rot13 ? rot13 : (patch: string) => patch
     )(applyPatch(
       reference.join("\n"), anomalies[anomaly]
     )).replace(/--(?!\S*\/)/g, "—")

--- a/articles/scp-3211/src/iframe.ts
+++ b/articles/scp-3211/src/iframe.ts
@@ -1,7 +1,7 @@
 import { applyPatch } from "diff"
 import Cookies from "js-cookie"
 
-import { anomalyNames, langs } from "./config"
+import type { anomalyNames, langs } from "./config"
 import { rot13 } from "./rot13"
 
 // Defined in iframe.ejs.html


### PR DESCRIPTION
The bundle should be entirely config- and language-agnostic. If another translation or anomaly is added or removed, the bundle must not need to change. Currently, this is not the case, because the iframe imports things from the config file. Instead, the relevant config items for the given language should be exposed directly to the window. This fixes #9.

Translations that use the current bundle (v2.0.1) will be fine left how they are, however, if they want to update to a newer version, the wikitext will need to be regenerated.

- [x] Do not include anomaly list in bundle
- [x] ~~Expose anomaly list to window~~ Not required - keys of `anomalies` are sufficient
- [x] Do not include language config in bundle
- [x] Expose language config to window

Although the config is currently only simple objects, #12 will require that config is passed through Babel, so I may as well get that out of the way now:

- [x] ~~Pass language config through Babel~~ Out of scope